### PR TITLE
Enable logging of eval episode statistics 

### DIFF
--- a/isaacgymenvs/learning/quadruped_amp_agent.py
+++ b/isaacgymenvs/learning/quadruped_amp_agent.py
@@ -1,0 +1,17 @@
+import isaacgymenvs.learning.amp_continuous as amp_continuous
+
+class QuadrupedAMPAgent(amp_continuous.AMPAgent):
+
+    def play_eval_steps(self):
+        """ Play steps to record episode statistics """
+        self.set_eval()
+        # TODO: fill this in 
+
+    def eval_epoch(self):
+        # TODO: fill this in
+        pass 
+
+    def train_epoch(self):
+        train_info = super().train_epoch(self)
+        eval_info = self.eval_epoch(self)
+        return train_info


### PR DESCRIPTION
Enable logging of eval statistics as follows:

At the end of each training epoch, initiate an evaluation epoch. 
During an evaluation epoch: 
- Reset all envs to their initial state
- Play steps normally and record various quantities using existing `TensorHistory` functionality
- Record relevant episode statistics (e.g. task following) 
- Reset all envs to their initial state again (for subsequent training epoch)